### PR TITLE
moved campaign specific find_by_name to the campaign model

### DIFF
--- a/adcloud.gemspec
+++ b/adcloud.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'activesupport', "~>3.2.6"
   gem.add_dependency 'faraday'
   gem.add_dependency 'faraday_middleware'
+  gem.add_dependency 'json', '~> 1.7.7'
 end

--- a/lib/adcloud/campaign.rb
+++ b/lib/adcloud/campaign.rb
@@ -82,5 +82,11 @@ module Adcloud
       self.validate
       self.errors.empty?
     end
+
+    # @return [Object] The entity with the unique identifier
+    def find_by_name(name)
+      result = connection.get("campaigns/find_by_name", name: name)
+      result["items"].map { |raw_campaign| self.new(raw_campaign) }
+    end
   end
 end

--- a/lib/adcloud/entity.rb
+++ b/lib/adcloud/entity.rb
@@ -82,12 +82,6 @@ module Adcloud
         self.new(result)
       end
 
-      # @return [Object] The entity with the unique identifier
-      def find_by_name(name)
-        result = connection.get("campaigns/find_by_name", name: name)
-        result["items"].map { |raw_campaign| self.new(raw_campaign) }
-      end
-
       # @return [Enitity] Object has errors when creation failed
       def create(params = {})
         entity = self.new(params)


### PR DESCRIPTION
find_by_name contains an implementation specific to the campaign model, but was declared in the generic entity class.

also added a dependency for a up to date json gem.
