### PR TITLE
1. Added to_s to adcloudapi exception so that we can just output ex and ...

### DIFF
--- a/lib/adcloud.rb
+++ b/lib/adcloud.rb
@@ -33,6 +33,7 @@ module Adcloud
   autoload :WebhookEvent, "adcloud/webhook_event"
 
   module AdcloudUnknownAPIError; class InvalidApiResponse < StandardError; end; end
+  class UnknownError < ApiError; end
   class BadRequestError < ApiError; end
   class NotFoundError < ApiError; end
   class ServerError < ApiError; end

--- a/lib/adcloud/api_error.rb
+++ b/lib/adcloud/api_error.rb
@@ -28,6 +28,10 @@ module Adcloud
       self.meta["status"]
     end
 
+    def to_s
+      self.response.message
+    end
+
   end
 
 end

--- a/lib/adcloud/exception_raiser.rb
+++ b/lib/adcloud/exception_raiser.rb
@@ -15,7 +15,7 @@ module Adcloud
       when 500
         raise Adcloud::ServerError.new(response)
       else
-        raise StandardError.new("Could not handle status #{response.status}")
+        raise Adcloud::UnknownError.new(response)
       end
     end
 


### PR DESCRIPTION
1. Added to_s to adcloudapi exception so that we can just output ex and not ex.message (seems to be what everyone is doing and will help with debugging)
2. Added better exception handling.. in the else case the api was simply returning a standard error with the response.status.. which is pretty useless in some cases (ssl,timeouts,etc) so now it throws ab UnknownError that acts in the standard adcloud manner
